### PR TITLE
Fixes Python3 support and improves formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,24 @@
+[flake8]
+exclude =
+	.git,
+	.idea,
+	__pycache__,
+	doc,
+	logs,
+	__init__.py,
+max-line-length = 150
+max-complexity = 10
+filename = *.py
+format = default
+inline-quotes = "
+ignore =
+	# E221 multiple spaces before operator
+	E221,
+	# whitespace before ':'
+	E203,
+	# whitespace before ')'
+	E202,
+	# multiple spaces after ','
+	E241,
+	# unexpected spaces around keyword / parameter equals
+	E251

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,94 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+#project files
+cached_uglify
+.idea
+

--- a/liqpay/__init__.py
+++ b/liqpay/__init__.py
@@ -1,1 +1,6 @@
-__author__ = 'user'
+import sys
+
+if sys.version_info >= (3, 0):
+    from .liqpay3 import *
+else:
+    from .liqpay import *

--- a/liqpay/liqpay3.py
+++ b/liqpay/liqpay3.py
@@ -44,7 +44,7 @@ class LiqPay(object):
     def _make_signature(self, *args):
         joined_fields = ''.join(x for x in args)
         joined_fields = joined_fields.encode('utf-8')
-        return base64.b64encode(hashlib.sha1(joined_fields).digest())
+        return base64.b64encode(hashlib.sha1(joined_fields).digest()).decode("ascii")
 
     def _prepare_params(self, params):
         params = {} if params is None else deepcopy(params)
@@ -83,11 +83,14 @@ class LiqPay(object):
             currency=currency if currency != 'RUR' else 'RUB',
             sandbox=int(bool(params.get('sandbox')))
         )
-        params_templ = {'data': base64.b64encode(json.dumps(params))}
+
+        encoded_data = base64.b64encode(json.dumps(params).encode("utf-8")).decode("ascii")
+        params_templ = {'data': encoded_data}
+
         params_templ['signature'] = self._make_signature(self._private_key, params_templ['data'], self._private_key)
         form_action_url = urljoin(self._host, '3/checkout/')
         format_input = lambda k, v: self.INPUT_TEMPLATE.format(name=k, value=v)
-        inputs = [format_input(k, v) for k, v in params_templ.iteritems()]
+        inputs = [format_input(k, v) for k, v in params_templ.items()]
         return self.FORM_TEMPLATE.format(
             action=form_action_url,
             language=language,

--- a/liqpay/liqpay3.py
+++ b/liqpay/liqpay3.py
@@ -97,8 +97,9 @@ class LiqPay(object):
 
     def cnb_signature(self, params):
         params = self._prepare_params(params)
-        print(base64.b64encode(json.dumps(params)))
-        return self._make_signature(self._private_key, base64.b64encode(json.dumps(params)), self._private_key)
+
+        data_to_sign = base64.b64encode(json.dumps(params).encode("utf-8")).decode("ascii")
+        return self._make_signature(self._private_key, data_to_sign, self._private_key)
 
     def str_to_sign(self, str):
-        return base64.b64encode(hashlib.sha1(str).digest())
+        return base64.b64encode(hashlib.sha1(str.encode("utf-8")).digest()).decode("ascii")

--- a/liqpay/liqpay3.py
+++ b/liqpay/liqpay3.py
@@ -5,8 +5,8 @@ supports python 3 version
 requires requests module
 """
 
-__title__ = 'LiqPay Python SDK'
-__version__ = '1.0'
+__title__ = "LiqPay Python SDK"
+__version__ = "1.0"
 
 import base64
 from copy import deepcopy
@@ -17,33 +17,31 @@ from urllib.parse import urljoin
 import requests
 
 
-
-
 class ParamValidationError(Exception):
     pass
 
 
 class LiqPay(object):
-    FORM_TEMPLATE = u'''\
-<form method="post" action="{action}" accept-charset="utf-8">
-\t{param_inputs}
-    <input type="image" src="//static.liqpay.com/buttons/p1{language}.radius.png" name="btn_text" />
-</form>'''
-    INPUT_TEMPLATE = u'<input type="hidden" name="{name}" value="{value}"/>'
+    FORM_TEMPLATE = """\
+        <form method="post" action="{action}" accept-charset="utf-8">
+        \t{param_inputs}
+            <input type="image" src="//static.liqpay.com/buttons/p1{language}.radius.png" name="btn_text" />
+        </form>"""
+    INPUT_TEMPLATE = "<input type='hidden' name='{name}' value='{value}'/>"
 
     SUPPORTED_PARAMS = [
-        'public_key', 'amount', 'currency', 'description', 'order_id',
-        'result_url', 'server_url', 'type', 'signature', 'language', 'sandbox'
+        "public_key", "amount", "currency", "description", "order_id",
+        "result_url", "server_url", "type", "signature", "language", "sandbox"
     ]
 
-    def __init__(self, public_key, private_key, host='https://www.liqpay.com/api/'):
+    def __init__(self, public_key, private_key, host="https://www.liqpay.com/api/"):
         self._public_key = public_key
         self._private_key = private_key
         self._host = host
 
     def _make_signature(self, *args):
-        joined_fields = ''.join(x for x in args)
-        joined_fields = joined_fields.encode('utf-8')
+        joined_fields = "".join(x for x in args)
+        joined_fields = joined_fields.encode("utf-8")
         return base64.b64encode(hashlib.sha1(joined_fields).digest()).decode("ascii")
 
     def _prepare_params(self, params):
@@ -59,42 +57,42 @@ class LiqPay(object):
         signature = self._make_signature(private_key, json_encoded_params, private_key)
 
         request_url = urljoin(self._host, url)
-        request_data = {'data': json_encoded_params, 'signature': signature}
+        request_data = {"data": json_encoded_params, "signature": signature}
         response = requests.post(request_url, data=request_data, verify=False)
-        return json.loads(response.content.decode('utf-8'))
+        return json.loads(response.content.decode("utf-8"))
 
     def cnb_form(self, params):
         params = self._prepare_params(params)
         params_validator = (
-            ('amount', lambda x: x is not None and float(x) > 0),
-            ('description', lambda x: x is not None)
+            ("amount", lambda x: x is not None and float(x) > 0),
+            ("description", lambda x: x is not None)
         )
         for key, validator in params_validator:
             if validator(params.get(key)):
                 continue
 
-            raise ParamValidationError('Invalid param: "%s"' % key)
+            raise ParamValidationError("Invalid param: '{}'".format(key))
 
         # spike to set correct values for language, currency and sandbox params
-        language = params.get('language', 'ru')
-        currency = params['currency']
+        language = params.get("language", "ru")
+        currency = params["currency"]
         params.update(
             language=language,
-            currency=currency if currency != 'RUR' else 'RUB',
-            sandbox=int(bool(params.get('sandbox')))
+            currency=currency if currency != "RUR" else "RUB",
+            sandbox=int(bool(params.get("sandbox")))
         )
 
         encoded_data = base64.b64encode(json.dumps(params).encode("utf-8")).decode("ascii")
-        params_templ = {'data': encoded_data}
+        params_templ = {"data": encoded_data}
 
-        params_templ['signature'] = self._make_signature(self._private_key, params_templ['data'], self._private_key)
-        form_action_url = urljoin(self._host, '3/checkout/')
-        format_input = lambda k, v: self.INPUT_TEMPLATE.format(name=k, value=v)
+        params_templ["signature"] = self._make_signature(self._private_key, params_templ["data"], self._private_key)
+        form_action_url = urljoin(self._host, "3/checkout/")
+        format_input = (lambda k, v: self.INPUT_TEMPLATE.format(name=k, value=v))
         inputs = [format_input(k, v) for k, v in params_templ.items()]
         return self.FORM_TEMPLATE.format(
             action=form_action_url,
             language=language,
-            param_inputs=u'\n\t'.join(inputs)
+            param_inputs="\n\t".join(inputs)
         )
 
     def cnb_signature(self, params):


### PR DESCRIPTION
**Fixes issues with Python3 support**
* wrong string encoding/decoding;
* wrong navigation through  dictionaries

**Improves formatting and Python3 syntax support:**
* all strings unicode by default, all u" removed;
* formatting improved using flake8 linter (configuration file added).

**Adds conditional import**
* ```__init__.py``` now conditionally includes needful files.

Warning! Tests still broken!

http://lucumr.pocoo.org/2014/1/5/unicode-in-2-and-3/
> The main difference between Python 2 and Python 3 is the basic types that exist to deal with texts and bytes. On Python 3 we have one text type: str which holds Unicode data and two byte types bytes and bytearray.

