### PR TITLE
Added decoding unquote function

### DIFF
--- a/liqpay/liqpay3.py
+++ b/liqpay/liqpay3.py
@@ -12,7 +12,7 @@ import base64
 from copy import deepcopy
 import hashlib
 import json
-from urllib.parse import urljoin
+from urllib.parse import urljoin, unquote
 
 import requests
 
@@ -134,4 +134,4 @@ class LiqPay(object):
             {'commission_credit': 0.0, 'order_id': 'order_id_1', 'liqpay_order_id': 'T8SRXWM71509085055293216', ...}
 
         """
-        return json.loads(base64.b64decode(data).decode('utf-8'))
+        return json.loads(base64.b64decode(unquote(data)).decode('utf-8'))


### PR DESCRIPTION
The fact is that the response about the payment status comes to the server in the format of an encoded link, and there the equal signs that we need for the correct base64 encoding length are replaced by %3D characters, which is why the byte string cannot be translated into a json dictionary, in this commit I fixed this situation, also if a string with equal signs comes, nothing will break.