### PR TITLE
fix signature

### DIFF
--- a/liqpay/liqpay3.py
+++ b/liqpay/liqpay3.py
@@ -132,7 +132,7 @@ class LiqPay(object):
         params = self._prepare_params(params)
 
         data_to_sign = self.data_to_sign(params)
-        return self._make_signature(self._private_key, data_to_sign, self._private_key)
+        return self._make_signature(self._private_key, data_to_sign)
 
     def cnb_data(self, params):
         params = self._prepare_params(params)


### PR DESCRIPTION
When try to create signature got 
TypeError: LiqPay._make_signature() takes 3 positional arguments but 4 were given
because of doubling argument self._private_key)